### PR TITLE
Support pg dumps created with CVE-2018-1058 patched pg_dump

### DIFF
--- a/lib/fake_pipe/postgres/comment_block.rb
+++ b/lib/fake_pipe/postgres/comment_block.rb
@@ -5,7 +5,7 @@ module FakePipe
     # Finds Postgres comment DML.
     class CommentBlock < TextBlock
 
-      self.start_pattern = /^COMMENT ON COLUMN (?<table>[^\.]+)\.(?<column>\S+) IS '(?<comment>.*)';/
+      self.start_pattern = /^COMMENT ON COLUMN (?<table>.+)\.(?<column>\S+) IS '(?<comment>.*)';/
       self.end_pattern = /^$/
 
       def on_start_text(match, line)

--- a/spec/anonymizer_spec.rb
+++ b/spec/anonymizer_spec.rb
@@ -41,7 +41,14 @@ COPY users (id, email) FROM stdin;
         let(:sql) {<<-SQL
 COMMENT ON COLUMN public.users.email IS 'anon: email';
 
+COMMENT ON COLUMN "tenant1".users.email IS 'anon: email';
+
 COPY public.users (id, email) FROM stdin;
+0	a@example.com
+1	b@example.com
+\.
+
+COPY "tenant1".users (id, email) FROM stdin;
 0	a@example.com
 1	b@example.com
 \.
@@ -50,7 +57,14 @@ COPY public.users (id, email) FROM stdin;
         let(:faked_sql) {<<-SQL
 COMMENT ON COLUMN public.users.email IS 'anon: email';
 
+COMMENT ON COLUMN "tenant1".users.email IS 'anon: email';
+
 COPY public.users (id, email) FROM stdin;
+0	foo@faked.com
+1	foo@faked.com
+\.
+
+COPY "tenant1".users (id, email) FROM stdin;
 0	foo@faked.com
 1	foo@faked.com
 \.

--- a/spec/anonymizer_spec.rb
+++ b/spec/anonymizer_spec.rb
@@ -4,34 +4,69 @@ module FakePipe
   describe Piper do
     let(:outputter) { StringIO.new }
 
-    context 'Emails' do
-      let(:sql) {<<-SQL
+    describe 'postgres' do
+      context 'PG version before CVE-2018-1058' do
+        let(:sql) {<<-SQL
 COMMENT ON COLUMN users.email IS 'anon: email';
 
 COPY users (id, email) FROM stdin;
 0	a@example.com
 1	b@example.com
 \.
-                 SQL
-      }
-      let(:faked_sql) {<<-SQL
+                   SQL
+        }
+        let(:faked_sql) {<<-SQL
 COMMENT ON COLUMN users.email IS 'anon: email';
 
 COPY users (id, email) FROM stdin;
 0	foo@faked.com
 1	foo@faked.com
 \.
-      SQL
-      }
-      before do
-        allow(Mutator).to receive(:mutate_email).and_return("foo@faked.com")
+                         SQL
+        }
+        before do
+          allow(Mutator).to receive(:mutate_email).and_return("foo@faked.com")
+        end
+
+        it 'anonymizes the dump' do
+          output = StringIO.new
+          instance = described_class.new(io: StringIO.new(sql), outputter: output, adapter: 'postgres')
+          instance.run
+          output.rewind
+          expect(output.read).to eq(faked_sql)
+        end
       end
-      it 'handles email' do
-        output = StringIO.new
-        instance = described_class.new(io: StringIO.new(sql), outputter: output, adapter: 'postgres')
-        instance.run
-        output.rewind
-        expect(output.read).to eq(faked_sql)
+
+      context 'PG version after CVE-2018-1058' do
+        let(:sql) {<<-SQL
+COMMENT ON COLUMN public.users.email IS 'anon: email';
+
+COPY public.users (id, email) FROM stdin;
+0	a@example.com
+1	b@example.com
+\.
+                   SQL
+        }
+        let(:faked_sql) {<<-SQL
+COMMENT ON COLUMN public.users.email IS 'anon: email';
+
+COPY public.users (id, email) FROM stdin;
+0	foo@faked.com
+1	foo@faked.com
+\.
+                         SQL
+        }
+        before do
+          allow(Mutator).to receive(:mutate_email).and_return("foo@faked.com")
+        end
+
+        it 'anonymizes the dump' do
+          output = StringIO.new
+          instance = described_class.new(io: StringIO.new(sql), outputter: output, adapter: 'postgres')
+          instance.run
+          output.rewind
+          expect(output.read).to eq(faked_sql)
+        end
       end
     end
   end


### PR DESCRIPTION
# Background
Postgres modified the output of `pg_dump` because if [CVE-2018-1058](https://www.postgresql.org/about/news/1834/). It now additionally adds the schema to the output.

This means that
```sql
COMMENT ON COLUMN users.name IS 'anon: full_name';
```
becomes

```sql
COMMENT ON COLUMN public.users.name IS 'anon: full_name';
```

# My Concerns
This regexp results in the correct behavior for me, but I'm not sure if it breaks something else. I'm concerned because it's a simplification of the regexp 😄 